### PR TITLE
Bug/32 image not changing

### DIFF
--- a/backend/migrations/changelogs/000000031_owned_tickets_view_fix.sql
+++ b/backend/migrations/changelogs/000000031_owned_tickets_view_fix.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+
+drop view if exists owned_tickets;
+
+CREATE OR REPLACE VIEW owned_tickets AS
+SELECT 
+  t.ticket_id,
+  e.event_id as event_id,
+  e.description AS event_description,
+  sp.billing_email AS stripe_receipt_email
+FROM tickets t
+JOIN events e ON t.event_id = e.event_id
+LEFT JOIN stripe_payments sp ON t.stripe_payment_id = sp.id;
+
+-- +goose Down
+
+DROP VIEW IF EXISTS owned_tickets; 

--- a/src/template/FilmClient.tsx
+++ b/src/template/FilmClient.tsx
@@ -62,6 +62,10 @@ export function FilmBackground({ metadata }: FilmClientProps) {
       if (metadata.mobileBoxart?.img) {
         setCurrentArt(metadata.mobileBoxart.img);
       }
+    } else {
+      if (metadata.boxart?.img) {
+        setCurrentArt(metadata.boxart.img);
+      }
     }
   }, [width, metadata.mobileBoxart?.img]);
 

--- a/src/template/FilmClient.tsx
+++ b/src/template/FilmClient.tsx
@@ -67,7 +67,7 @@ export function FilmBackground({ metadata }: FilmClientProps) {
         setCurrentArt(metadata.boxart.img);
       }
     }
-  }, [width, metadata.mobileBoxart?.img]);
+  }, [width, metadata.mobileBoxart?.img, metadata.boxart?.img]);
 
   function start(e: AnimationEvent) {
     if (e.animationName !== 'waiting') return;


### PR DESCRIPTION
This pull request includes updates to a database view and a frontend component to fix issues and improve functionality. The key changes involve modifying the `owned_tickets` view in the database and enhancing the logic for setting background images in the `FilmBackground` component.

### Database Updates:
* [`backend/migrations/changelogs/000000031_owned_tickets_view_fix.sql`](diffhunk://#diff-da97ee19a7db8d0375fa8920057e30c94bf2dbfc0ff8891de63b2054c63782e0R1-R17): Recreated the `owned_tickets` view to include additional fields such as `event_description` and `stripe_receipt_email`, while ensuring compatibility with existing data by using `CREATE OR REPLACE VIEW`.

### Frontend Enhancements:
* [`src/template/FilmClient.tsx`](diffhunk://#diff-5d6329e7545800b2cf48da3c6588d2a549f070ecb4e4e596693e9592d580f40dR65-R68): Updated the `FilmBackground` component to fall back to `metadata.boxart.img` when `metadata.mobileBoxart.img` is not available, ensuring a background image is always set.